### PR TITLE
Add note to make sure qBitTorrent port is configured in the qbittorrent-nox service before the script will work

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ Restart the service:
  ```sh
 sudo systemctl restart natpmpc_script
 ```
+
+[!IMPORTANT]
+Make sure your qbittorrent-nox service in `/etc/systemd/system/qbittorrent-nox.service` has a torrenting port configured at start-up, if no port is configured then qBittorrent will keep restarting everytime the script is ran.
+```
+[Service]
+ExecStart=/usr/bin/qbittorrent-nox --torrenting-port=<PORT>
+```
+
+To confirm the script will work, the command `grep -Po --max-count=1 '(?<=--torrenting-port=)[0-9]+' "/etc/systemd/system/qbittorrent-nox.service"` should give you an output of the configured torrenting port.
+
 ### Modify the script as needed
 Access the script with an editor of your choice, for example:
 ```cmd

--- a/README.md
+++ b/README.md
@@ -123,14 +123,13 @@ Restart the service:
 sudo systemctl restart natpmpc_script
 ```
 
-[!IMPORTANT]
-Make sure your qbittorrent-nox service in `/etc/systemd/system/qbittorrent-nox.service` has a torrenting port configured at start-up, if no port is configured then qBittorrent will keep restarting everytime the script is ran.
-```
-[Service]
-ExecStart=/usr/bin/qbittorrent-nox --torrenting-port=<PORT>
-```
-
-To confirm the script will work, the command `grep -Po --max-count=1 '(?<=--torrenting-port=)[0-9]+' "/etc/systemd/system/qbittorrent-nox.service"` should give you an output of the configured torrenting port.
+> [!IMPORTANT]
+> Make sure your qbittorrent-nox service in `/etc/systemd/system/qbittorrent-nox.service` has a torrenting port configured at start-up, if no port is configured then qBittorrent will keep restarting everytime the script is ran.
+> ```
+> [Service]
+> ExecStart=/usr/bin/qbittorrent-nox --torrenting-port=<PORT>
+> ```
+> To confirm the script will work, the command `grep -Po --max-count=1 '(?<=--torrenting-port=)[0-9]+' "/etc/systemd/system/qbittorrent-nox.service"` should give you an output of the configured torrenting port.
 
 ### Modify the script as needed
 Access the script with an editor of your choice, for example:


### PR DESCRIPTION
Should maybe fix the script to append a port if none is configured, but if no port is configured in the qbittorrent-nox service sed will fail to replace the text. When the script runs, it will keep coming back with an empty configured torrenting port, so it won't work properly.

Added a note about this to the README.